### PR TITLE
Services: first build: abs added

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,8 @@
+aggregate_check: false
+
+upload_channels:
+  - services
+
+channels:
+  - services
+


### PR DESCRIPTION
Needed for vaex (vaex-server=>ipyvolume=>ipywebrtc). 